### PR TITLE
Fix testing timeout 

### DIFF
--- a/contract/truffle-config.js
+++ b/contract/truffle-config.js
@@ -37,4 +37,7 @@ module.exports = {
       version: '0.6.12',
     },
   },
+  mocha: {
+    timeout: 10000
+  }
 }


### PR DESCRIPTION
Fix timeout error on contract test
```
  1) StakingPool
       tokensTotalSupply
         decremented by staking:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/circleci/project/contract/test/StakingPool.test.js)
      at listOnTimeout (internal/timers.js:549:17)
      at processTimers (internal/timers.js:492:7)
```