### PR TITLE
Fix account returns null and typo

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -7,7 +7,7 @@ type Creator @entity {
 type Account @entity {
   id: ID!
   tokens: [AccountToken!]! @derivedFrom(field: "account")
-  checkReuqest: [CheckRequest!]! @derivedFrom(field: "account")
+  checkRequests: [CheckRequest!]! @derivedFrom(field: "account")
   claims: [Claim!]! @derivedFrom(field: "account")
   # TODO: Disabled for this phase
   #  donates: [Donate!]! @derivedFrom(field: "account")

--- a/subgraph/src/campaign.ts
+++ b/subgraph/src/campaign.ts
@@ -1,4 +1,4 @@
-import { Claim, Campaign, CheckRequest } from "./types/schema";
+import { Claim, Campaign, CheckRequest, Account } from "./types/schema";
 import {
   AudiusFollowersCampaign,
   ChainlinkCancelled,
@@ -57,6 +57,14 @@ export function handleChainlinkRequested(event: ChainlinkRequested): void {
   if (checkRequest == null) {
     checkRequest = new CheckRequest(checkRequestId);
   }
+
+  let accountId = event.transaction.from.toHexString();
+  let account = Account.load(accountId);
+  if (account == null) {
+    account = new Account(accountId);
+  }
+  account.save();
+
   checkRequest.account = event.transaction.from.toHexString();
   checkRequest.campaign = event.address.toHexString();
   checkRequest.status = "IN_PROGRESS";


### PR DESCRIPTION
- Fix typo `checkReuqest` to `checkRequests` 
- Fixed account entity returns null even after check request if finished. 

Fixed code is already deployed. 
https://thegraph.com/explorer/subgraph/tart-tokyo/iroiro-rinkeby

```
{
  checkRequests {
    id
    account{
      id
    }
  }
}
```