### PR TITLE
Fix invalid subgraph's campaign claim amount

### DIFF
--- a/frontend/packages/react-app/src/interfaces.ts
+++ b/frontend/packages/react-app/src/interfaces.ts
@@ -76,7 +76,7 @@ export interface CampaignInfo {
   readonly campaignInfoCid: string;
   readonly recipientsCid: string;
   readonly claimAmount: string;
-  readonly claimedNum: number;
+  readonly claimedNum: string;
   readonly status: number;
   readonly claims: Claim[];
   readonly checkRequests: CheckRequest[];

--- a/frontend/packages/react-app/src/utils/mockData.ts
+++ b/frontend/packages/react-app/src/utils/mockData.ts
@@ -47,7 +47,7 @@ export const campaign: CampaignInfo = {
     id: "",
   },
   recipientsCid: "",
-  claimedNum: 100,
+  claimedNum: "100",
   claims: [],
   checkRequests: [],
 };

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -30,7 +30,7 @@ type Campaign @entity {
   campaignInfoCid: String
   recipientsCid: String
   claimAmount: BigInt
-  claimedNum: Int
+  claimedNum: BigInt
   status: Int
   claims: [Claim!]! @derivedFrom(field: "campaign")
   checkRequests: [CheckRequest!]! @derivedFrom(field: "campaign")

--- a/subgraph/src/distributor.ts
+++ b/subgraph/src/distributor.ts
@@ -59,7 +59,7 @@ export function handleCreateCampaign(event: CreateCampaign): void {
   if (callClaimedNum.reverted) {
     log.warning("Claimed num not found. Campaign: {}", [campaignId]);
   } else {
-    campaign.claimAmount = callClaimedNum.value;
+    campaign.claimedNum = callClaimedNum.value;
   }
   let callCampaignInfoCid = campaignContract.try_campaignInfoCid();
   if (callCampaignInfoCid.reverted) {


### PR DESCRIPTION
Fix campaign `claimAmount` returns `claimedNum` value. 

```
{
  campaigns {
    id
    claimAmount
  }
}
```